### PR TITLE
feat(dev): Add relay to enum definition

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const products = {
   gps: 0xc068,
   switch: 0xc069,
   solarcharger: 0xc06a,
+  relay: 0xc06b
 };
 
 function getType(value) {


### PR DESCRIPTION
Caused-by: https://victrondevelopment.slack.com/archives/C04RYU0UMDE/p1737716987374599?thread_ts=1736888039.745289&cid=C04RYU0UMDE

Easier to develop relay virtual-device while doing QA of firmware beta releases
Node-red stays working(not failing after reboot) while flow contains unknown virtual relay device
![image](https://github.com/user-attachments/assets/71be793e-5a86-44fb-a34c-5b92e797fdd3)

```
@400000006793748e022ab5dc 24 Jan 13:07:48 - [red] Uncaught Exception:
@400000006793748e02465814 24 Jan 13:07:48 - [error] TypeError: products.join is not a function
@400000006793748e02467b3c     at addDefaults (/usr/lib/node_modules/@victronenergy/node-red-contrib-victron/node_modules/dbus-victron-virtual/src/index.js:220:64)
@400000006793748e02468ec4     at addVictronInterfaces (/usr/lib/node_modules/@victronenergy/node-red-contrib-victron/node_modules/dbus-victron-virtual/src/index.js:240:5)
@400000006793748e0246a634     at proceed (/usr/lib/node_modules/@victronenergy/node-red-contrib-victron/src/nodes/victron-virtual.js:488:11)
@400000006793748e02483c74     at processTicksAndRejections (node:internal/process/task_queues:95:5)
```
