### PR TITLE
Reduce amount of installed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
   "dependencies": {
     "dbus-native-victron": "^0.4.3",
     "debug": "^4.3.7"
-  }
+  },
+  "files": [
+    "src/index.js"
+  ]
 }


### PR DESCRIPTION
No longer install files that aren't needed for using the library, thus saving some disk space.