### PR TITLE
Add onPropertiesChanged to support derived (or "calculated") properties

### DIFF
--- a/src/__tests__/setValueWithOnPropertiesChangedTest.js
+++ b/src/__tests__/setValueWithOnPropertiesChangedTest.js
@@ -1,0 +1,43 @@
+/* eslint-env node */
+const { addVictronInterfaces } = require("../index");
+
+describe("victron-dbus-virtual, setValue with onPropertiesChanged tests", () => {
+  it("works for the happy case", async () => {
+    const declaration = { name: "foo", properties: { StringProp: "s", DerivedProp: "s" } };
+    const definition = { StringProp: "hello", DerivedProp: "derived" };
+    const bus = {
+      exportInterface: () => { },
+      invoke: function(args, cb) {
+        process.nextTick(() => cb(null, args));
+      },
+    };
+    function onPropertiesChanged({ changes, instance }) {
+      changes.DerivedProp = instance.StringProp + " world";
+      return changes;
+    }
+    const { setValue } = addVictronInterfaces(
+      bus,
+      declaration,
+      definition,
+      false,
+      onPropertiesChanged
+    );
+
+    const result = await setValue({
+      path: "/StringProp",
+      value: "forty-two",
+      destination: "foo",
+      interface_: "foo",
+    });
+    expect(result.member).toBe("SetValue");
+    expect(result.body).toStrictEqual([["s", "forty-two"]]);
+    expect(result.path).toBe("/StringProp");
+    expect(result.interface).toBe("foo");
+    expect(result.destination).toBe("foo");
+
+    // NOTE: calling setValue() does *not* change the definition, compare comment in ./setValueTest.js
+    expect(definition.StringProp).toBe("hello");
+    expect(definition.DerivedProp).toBe("derived");
+  });
+});
+

--- a/src/__tests__/setValuesLocallyTest.js
+++ b/src/__tests__/setValuesLocallyTest.js
@@ -95,7 +95,68 @@ describe("victron-dbus-virtual, setValuesLocally", () => {
     expect(definition.ReadOnlyProp).toBe("original");
     expect(definition.WritableProp).toBe("original");
   });
-})
+
+  describe("setValuesLocally with onPropertiesChanged", () => {
+    it("calls onPropertiesChanged callback and updates the definition accordingly", () => {
+      const declaration = { name: "foo", properties: { StringProp: "s", DerivedProp: "s" } };
+      const definition = { StringProp: "(nothing yet)", DerivedProp: "derived" };
+      const bus = {
+        exportInterface: () => { },
+      };
+      const onPropertiesChanged = jest.fn(({ changes, instance }) => {
+        console.log("onPropertiesChanged called with changes:", changes, "instance:", instance);
+        const result = { ...changes }
+        if (changes.StringProp) {
+          result.DerivedProp = changes.StringProp + " world";
+        }
+        return result;
+      });
+
+      const { setValuesLocally } = addVictronInterfaces(
+        bus,
+        declaration,
+        definition,
+        false,
+        null,
+        onPropertiesChanged
+      );
+
+      setValuesLocally({ StringProp: "hello" });
+
+      expect(onPropertiesChanged).toHaveBeenCalledWith({
+        changes: { StringProp: "hello" },
+        instance: definition
+      });
+
+      expect(definition.StringProp).toBe("hello");
+      expect(definition.DerivedProp).toBe("hello world");
+
+    });
+    it("fails if onPropertiesChanged returns invalid properties", () => {
+      const declaration = { name: "foo", properties: { StringProp: "s", DerivedProp: "s" } };
+      const definition = { StringProp: "(nothing yet)", DerivedProp: "derived" };
+      const bus = {
+        exportInterface: () => { },
+      };
+      const onPropertiesChanged = jest.fn(() => {
+        return { NonExistentProp: "value" };
+      });
+
+      const { setValuesLocally } = addVictronInterfaces(
+        bus,
+        declaration,
+        definition,
+        false,
+        null,
+        onPropertiesChanged
+      );
+
+      expect(() => {
+        setValuesLocally({ StringProp: "hello" });
+      }).toThrow("Property NonExistentProp not found in properties");
+    });
+  });
+});
 
 describe("victron-dbus-virtual, SetValues", () => {
 
@@ -152,4 +213,5 @@ describe("victron-dbus-virtual, SetValues", () => {
     expect(definition.ReadOnlyProp).toBe("original");
   });
 })
+
 

--- a/src/index.js
+++ b/src/index.js
@@ -380,12 +380,18 @@ async function getMax(bus, { path, interface_, destination }) {
   });
 }
 
+function defaultOnPropertiesChanged({ changes, instance }) {
+  console.log("defaultOnPropertiesChanged called with changes:", changes, "on instance:", instance);
+  return changes; // NOOP
+}
+
 function addVictronInterfaces(
   bus,
   declaration,
   definition,
   add_defaults = true,
-  emitCallback = null
+  emitCallback = null,
+  onPropertiesChanged = defaultOnPropertiesChanged
 ) {
   const warnings = [];
 
@@ -505,19 +511,38 @@ function addVictronInterfaces(
     },
     SetValues: function(values /* msg */) {
       debug(`SetValues called with values:`, values);
-      for (const [k, value] of values) {
+      for (const [k] of values) {
         if (!declaration.properties || !declaration.properties[k]) {
           throw new Error(`Property ${k} not found in properties.`);
         }
         if ((declaration.properties[k] || {}).readonly) {
           return -1;
         }
-        definition[k] = validateNewValue(k, declaration.properties[k], unwrapValue(value));
+      }
+      const changes = {}
+      for (const [k, value] of values) {
+        changes[k] = validateNewValue(k, declaration.properties[k], unwrapValue(value));
+      }
+      const changedProperties = onPropertiesChanged({ changes, instance: iface });
+      // TODO: do similar validation to what we do in SetValue below
+
+      for (const k of Object.keys(changedProperties)) {
+        if (!declaration.properties || !declaration.properties[k]) {
+          throw new Error(`Property ${k} not found in properties.`);
+        }
+        if ((declaration.properties[k] || {}).readonly) {
+          console.warn(`Property ${k} is readonly and cannot be set, but it is being set by 'onPropertiesChanged'.`);
+        }
+
       }
 
-      debug(`SetValues updated definition:`, definition);
+      for (const k of Object.keys(changedProperties)) {
+        definition[k] = changedProperties[k];
+      }
+
+      debug(`SetValues updated properties:`, changedProperties);
       // TODO: we must include changed values only.
-      iface.emit("ItemsChanged", getProperties(Object.keys(values), true));
+      iface.emit("ItemsChanged", getProperties(Object.keys(changedProperties), true));
       return 0;
     },
     emit: function(name, args) {
@@ -552,11 +577,16 @@ function addVictronInterfaces(
       }
     }
 
+    const changes = {}
     for (const k of Object.keys(sanitizedValues)) {
-      definition[k] = validateNewValue(k, declaration.properties[k], sanitizedValues[k]);
+      changes[k] = validateNewValue(k, declaration.properties[k], sanitizedValues[k]);
     }
+    const changedProperties = onPropertiesChanged({ changes, instance: iface });
     debug(`setValuesLocally updated definition:`, definition);
-    iface.emit("ItemsChanged", getProperties(Object.keys(sanitizedValues), true));
+    for (const k of Object.keys(changedProperties)) {
+      definition[k] = changedProperties[k];
+    }
+    iface.emit("ItemsChanged", getProperties(Object.keys(changedProperties), true));
   }
 
   const ifaceDesc = {
@@ -783,8 +813,28 @@ function addVictronInterfaces(
             return -1;
           }
           try {
-            definition[k] = validateNewValue(k, declaration.properties[k], unwrapValue(value));
-            iface.emit("ItemsChanged", getProperties([k], true));
+            const changes = {
+              [k]: validateNewValue(k, declaration.properties[k], unwrapValue(value))
+            };
+
+            const changedProperties = onPropertiesChanged({ changes, instance: iface });
+
+            // validate that changedProperties only contains valid properties, warn about read-only properties
+            for (const changedKey of Object.keys(changedProperties)) {
+              if (!declaration.properties || !declaration.properties[changedKey]) {
+                throw new Error(`Property ${changedKey} not found in properties.`);
+              }
+              if ((declaration.properties[changedKey] || {}).readonly) {
+                console.warn(`Property ${changedKey} is readonly and cannot be set, but it is being set by 'onPropertiesChanged'.`);
+              }
+            }
+
+            // validation done, now update definition with all changed properties
+            for (const changedKey of Object.keys(changedProperties)) {
+              definition[changedKey] = validateNewValue(changedKey, declaration.properties[changedKey], changedProperties[changedKey]);
+            }
+
+            iface.emit("ItemsChanged", getProperties(Object.keys(changedProperties), true));
             return 0;
           } catch (e) {
             console.error(e);

--- a/src/index.js
+++ b/src/index.js
@@ -476,6 +476,25 @@ function addVictronInterfaces(
     }
   };
 
+  function processPropertyChanges({ changes: values }) {
+    const changes = {}
+    debug("processPropertyChanges called with values:", values);
+    for (const [k, value] of Object.entries(values)) {
+      changes[k] = validateNewValue(k, declaration.properties[k], value);
+    }
+    const changedProperties = onPropertiesChanged({ changes, instance: definition });
+
+    for (const k of Object.keys(changedProperties)) {
+      if (!declaration.properties || !declaration.properties[k]) {
+        throw new Error(`Property ${k} not found in properties.`);
+      }
+      // we allow readonly properties to be changed through onPropertiesChanged, but
+      // not through SetValue, so we don't check readonly here.
+    }
+
+    return changedProperties;
+  }
+
   // we use this for GetItems and ItemsChanged.
   function getProperties(limitToPropertyNames = [], prependSlash = false) {
     // Filter entries based on specificItem if provided
@@ -511,30 +530,17 @@ function addVictronInterfaces(
     },
     SetValues: function(values /* msg */) {
       debug(`SetValues called with values:`, values);
-      for (const [k] of values) {
+      const changes = {}
+      for (const [k, value] of values) {
         if (!declaration.properties || !declaration.properties[k]) {
           throw new Error(`Property ${k} not found in properties.`);
         }
         if ((declaration.properties[k] || {}).readonly) {
           return -1;
         }
-      }
-      const changes = {}
-      for (const [k, value] of values) {
         changes[k] = validateNewValue(k, declaration.properties[k], unwrapValue(value));
       }
-      const changedProperties = onPropertiesChanged({ changes, instance: iface });
-      // TODO: do similar validation to what we do in SetValue below
-
-      for (const k of Object.keys(changedProperties)) {
-        if (!declaration.properties || !declaration.properties[k]) {
-          throw new Error(`Property ${k} not found in properties.`);
-        }
-        if ((declaration.properties[k] || {}).readonly) {
-          console.warn(`Property ${k} is readonly and cannot be set, but it is being set by 'onPropertiesChanged'.`);
-        }
-
-      }
+      const changedProperties = processPropertyChanges({ changes });
 
       for (const k of Object.keys(changedProperties)) {
         definition[k] = changedProperties[k];
@@ -577,15 +583,11 @@ function addVictronInterfaces(
       }
     }
 
-    const changes = {}
-    for (const k of Object.keys(sanitizedValues)) {
-      changes[k] = validateNewValue(k, declaration.properties[k], sanitizedValues[k]);
-    }
-    const changedProperties = onPropertiesChanged({ changes, instance: iface });
-    debug(`setValuesLocally updated definition:`, definition);
+    const changedProperties = processPropertyChanges({ changes: sanitizedValues });
     for (const k of Object.keys(changedProperties)) {
       definition[k] = changedProperties[k];
     }
+    debug(`setValuesLocally updated definition:`, definition);
     iface.emit("ItemsChanged", getProperties(Object.keys(changedProperties), true));
   }
 
@@ -813,23 +815,14 @@ function addVictronInterfaces(
             return -1;
           }
           try {
-            const changes = {
-              [k]: validateNewValue(k, declaration.properties[k], unwrapValue(value))
-            };
 
-            const changedProperties = onPropertiesChanged({ changes, instance: iface });
-
-            // validate that changedProperties only contains valid properties, warn about read-only properties
-            for (const changedKey of Object.keys(changedProperties)) {
-              if (!declaration.properties || !declaration.properties[changedKey]) {
-                throw new Error(`Property ${changedKey} not found in properties.`);
+            const changedProperties = processPropertyChanges({
+              changes: {
+                [k]: validateNewValue(k, declaration.properties[k], unwrapValue(value))
               }
-              if ((declaration.properties[changedKey] || {}).readonly) {
-                console.warn(`Property ${changedKey} is readonly and cannot be set, but it is being set by 'onPropertiesChanged'.`);
-              }
-            }
+            })
 
-            // validation done, now update definition with all changed properties
+            // validation done, update definition with all changed properties
             for (const changedKey of Object.keys(changedProperties)) {
               definition[changedKey] = validateNewValue(changedKey, declaration.properties[changedKey], changedProperties[changedKey]);
             }


### PR DESCRIPTION
This allows an implementation of interfaces to "react" to property changes, by e.g. determining derived values or calculated properties. The following example demonstrates how to increase a counter on every change of a specific property:

```js
function onPropertiesChanged({ changes, instance }) {
  if (changes.someMeasurement) {
    changes.someMeasurementChangeCount = instance.someMeasurementChangeCount + 1;
  }
  return changes;
}
```

The value returned from `onPropertiesChanged()` is an object containing all key/value pairs to change.

This design allows implementing filters as well, e.g. by saying `delete changes.someMeasurement` inside of `onPropertiesChanged()` an intended property change can be blocked.

Note that, for now, the implementation of `onPropertiesChanged()` cannot be async, but this may be a future extension.

Additional context for this extension of `addVictronInterfaces()` is [in this PR comment](https://github.com/victronenergy/node-red-contrib-victron/pull/457#pullrequestreview-4136168860) and related links.
