### PR TITLE
feat: allow callers to override Mgmt/Connection in addDefaults

### DIFF
--- a/src/__tests__/mgmtConnectionOverrideTest.js
+++ b/src/__tests__/mgmtConnectionOverrideTest.js
@@ -1,0 +1,78 @@
+/* eslint-env node */
+const { addVictronInterfaces } = require("../index");
+
+describe("Mgmt/Connection override", () => {
+  it("sets Mgmt/Connection as readonly by default", () => {
+    const bus = { exportInterface: jest.fn() };
+    const declaration = { name: "com.victronenergy.ev.virtual_test", properties: { Soc: { type: "d" } } };
+    const definition = { Soc: null };
+
+    addVictronInterfaces(bus, declaration, definition);
+
+    expect(declaration.properties["Mgmt/Connection"].readonly).toBe(true);
+    expect(definition["Mgmt/Connection"]).toBe("Node-RED");
+  });
+
+  it("respects a pre-declared Mgmt/Connection without readonly", () => {
+    const bus = { exportInterface: jest.fn() };
+    const declaration = {
+      name: "com.victronenergy.ev.virtual_test",
+      properties: { Soc: { type: "d" }, "Mgmt/Connection": { type: "s" } }
+    };
+    const definition = { Soc: null, "Mgmt/Connection": null };
+
+    addVictronInterfaces(bus, declaration, definition);
+
+    expect(declaration.properties["Mgmt/Connection"].readonly).toBeUndefined();
+  });
+
+  it("allows setValuesLocally on a pre-declared Mgmt/Connection", () => {
+    const bus = { exportInterface: jest.fn() };
+    const declaration = {
+      name: "com.victronenergy.ev.virtual_test",
+      properties: { Soc: { type: "d" }, "Mgmt/Connection": { type: "s" } }
+    };
+    const definition = { Soc: null, "Mgmt/Connection": null };
+
+    const { setValuesLocally } = addVictronInterfaces(bus, declaration, definition);
+
+    expect(() => setValuesLocally({ "Mgmt/Connection": "Tesla Model 3" })).not.toThrow();
+    expect(definition["Mgmt/Connection"]).toBe("Tesla Model 3");
+  });
+
+  it("rejects setValuesLocally on default readonly Mgmt/Connection", () => {
+    const bus = { exportInterface: jest.fn() };
+    const declaration = { name: "com.victronenergy.ev.virtual_test", properties: { Soc: { type: "d" } } };
+    const definition = { Soc: null };
+
+    const { setValuesLocally } = addVictronInterfaces(bus, declaration, definition);
+
+    expect(() => setValuesLocally({ "Mgmt/Connection": "Custom" })).toThrow(/readonly/);
+  });
+
+  it("preserves an existing Mgmt/Connection value in the definition", () => {
+    const bus = { exportInterface: jest.fn() };
+    const declaration = {
+      name: "com.victronenergy.ev.virtual_test",
+      properties: { Soc: { type: "d" }, "Mgmt/Connection": { type: "s" } }
+    };
+    const definition = { Soc: null, "Mgmt/Connection": "pre-set value" };
+
+    addVictronInterfaces(bus, declaration, definition);
+
+    expect(definition["Mgmt/Connection"]).toBe("pre-set value");
+  });
+
+  it("sets default Mgmt/Connection value to Node-RED when definition has null", () => {
+    const bus = { exportInterface: jest.fn() };
+    const declaration = {
+      name: "com.victronenergy.ev.virtual_test",
+      properties: { Soc: { type: "d" }, "Mgmt/Connection": { type: "s" } }
+    };
+    const definition = { Soc: null, "Mgmt/Connection": null };
+
+    addVictronInterfaces(bus, declaration, definition);
+
+    expect(definition["Mgmt/Connection"]).toBe("Node-RED");
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -426,8 +426,12 @@ function addVictronInterfaces(
       );
       return;
     }
-    declaration["properties"]["Mgmt/Connection"] = { type: "s", readonly: true };
-    definition["Mgmt/Connection"] = "Node-RED";
+    if (!declaration["properties"]["Mgmt/Connection"]) {
+      declaration["properties"]["Mgmt/Connection"] = { type: "s", readonly: true };
+    }
+    if (definition["Mgmt/Connection"] == null) {
+      definition["Mgmt/Connection"] = "Node-RED";
+    }
     declaration["properties"]["Mgmt/ProcessName"] = { type: "s", readonly: true };
     definition["Mgmt/ProcessName"] = packageJson.name;
     declaration["properties"]["Mgmt/ProcessVersion"] = { type: "s", readonly: true };


### PR DESCRIPTION
`addDefaults()` previously unconditionally set `Mgmt/Connection` to `{ type: "s", readonly: true }` / "Node-RED", making it impossible for callers to supply a writable connection string (e.g. an EV vehicle identifier). Change both assignments to no-ops when the caller has already declared the property or set a non-null value.

The other `Mgmt/*` and `Product*` properties remain unconditional as they carry library-identity semantics that callers should not override.