### PR TITLE
fix: handle D-Bus uint32 ('u') type in wrapValue

### DIFF
--- a/src/__tests__/wrapValueTest.js
+++ b/src/__tests__/wrapValueTest.js
@@ -5,6 +5,7 @@ describe("victron-dbus-virtual, wrapValue", () => {
   it("works for basic types", () => {
     expect(wrapValue("s", "hello")).toStrictEqual(["s", "hello"]);
     expect(wrapValue("i", 42)).toStrictEqual(["i", 42]);
+    expect(wrapValue("u", 86400000)).toStrictEqual(["u", 86400000]);
     expect(wrapValue("b", true)).toStrictEqual(["b", true]);
     expect(wrapValue("d", 3.14)).toStrictEqual(["d", 3.14]);
   });

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,8 @@ function wrapValue(t, v) {
       return ["s", v];
     case "i":
       return ["i", v];
+    case "u":
+      return ["u", v];
     case "d":
       return ["d", v];
     case "ad":


### PR DESCRIPTION
wrapValue had no case for 'u', so it fell through to the default branch and returned a raw number instead of ['u', value]. Any property declared with type 'u' would then fail D-Bus marshalling with 'variant data should be [signature, data]'.