### PR TITLE
Fix unsigned int handling for local value updates (type u)

### DIFF
--- a/src/__tests__/setValuesLocallyTest.js
+++ b/src/__tests__/setValuesLocallyTest.js
@@ -77,6 +77,36 @@ describe("victron-dbus-virtual, setValuesLocally", () => {
 
   });
 
+  it("supports unsigned int values", async () => {
+    const declaration = { name: "foo", properties: { UtcTime: { type: "u" } } };
+    const definition = { UtcTime: 0 };
+    const bus = {
+      exportInterface: jest.fn(),
+    };
+
+    const { setValuesLocally } = addVictronInterfaces(bus, declaration, definition, false);
+
+    expect(() => {
+      setValuesLocally({ UtcTime: 63252000 });
+    }).not.toThrow();
+
+    expect(definition.UtcTime).toBe(63252000);
+  });
+
+  it("rejects negative unsigned int values", async () => {
+    const declaration = { name: "foo", properties: { UtcTime: { type: "u" } } };
+    const definition = { UtcTime: 0 };
+    const bus = {
+      exportInterface: jest.fn(),
+    };
+
+    const { setValuesLocally } = addVictronInterfaces(bus, declaration, definition, false);
+
+    expect(() => {
+      setValuesLocally({ UtcTime: -1 });
+    }).toThrow("out of range for unsigned int");
+  });
+
   it("trying to set readonly properties fails, without changing anything", () => {
     const declaration = { name: "foo", properties: { ReadOnlyProp: { type: "s", readonly: true }, WritableProp: "s" } };
     const definition = { ReadOnlyProp: "original", WritableProp: "original" };

--- a/src/__tests__/unwrapValueTest.js
+++ b/src/__tests__/unwrapValueTest.js
@@ -5,6 +5,7 @@ describe("victron-dbus-virtual, unwrapValue", () => {
   it("works for basic types", () => {
     expect(unwrapValue([[{ type: "s" }], ["hello"]])).toBe("hello");
     expect(unwrapValue([[{ type: "i" }], [42]])).toBe(42);
+    expect(unwrapValue([[{ type: "u" }], [86400000]])).toBe(86400000);
     expect(unwrapValue([[{ type: "d" }], [42.1]])).toBe(42.1);
     expect(unwrapValue([[{ type: "b" }], [42]])).toBe(true);
     expect(unwrapValue([[{ type: "ad" }], [[42.1, 42.2]]])).toStrictEqual([42.1, 42.2]);

--- a/src/index.js
+++ b/src/index.js
@@ -102,6 +102,8 @@ function unwrapValue([t, v]) {
       return v[0];
     case "i":
       return Number(v[0]);
+    case "u":
+      return Number(v[0]);
     case "d":
       return Number(v[0]);
     case "ad":
@@ -153,13 +155,18 @@ function validateNewNumber(name, declaration, value) {
   if (isNaN(number)) {
     throw new Error(`value for ${name} is not a number.`);
   }
+  if (declaration.type === "u") {
+    if (!Number.isFinite(number) || number < 0 || number > 0xFFFFFFFF) {
+      throw new Error(`value for ${name} is out of range for unsigned int`);
+    }
+  }
   if (declaration.max !== undefined && number > declaration.max) {
     throw new Error(`value for ${name} is too large`);
   }
   if (declaration.min !== undefined && number < declaration.min) {
     throw new Error(`value for ${name} is too small`);
   }
-  if (declaration.type === "i") {
+  if (declaration.type === "i" || declaration.type === "u") {
     return Math.floor(number);
   } else {
     return number;
@@ -190,6 +197,7 @@ function validateNewValue(name, declaration, value) {
         }
         throw new Error(`validation failed for ${name}, type ${declaration.type}, check logs for details.`)
       case 'i':
+      case 'u':
       case 'd':
         if (Array.isArray(value) && value.length > 0) {
           throw new Error(`value for ${name} cannot be an array`);


### PR DESCRIPTION
### Summary
This PR fixes an issue where properties declared as unsigned int (type u) could fail when updated through local value paths, even though wrapping support for type u already existed.

### Problem
When updating unsigned properties (for example GPS UtcTime), updates could fail with an error similar to:

Failed to apply debounced value for /UtcTime: Data: 63252000 was not of type number

### Root Cause
Unsigned values were only partially supported:

Wrapping logic supported type u.
Validation and unwrapping logic did not fully handle type u.
As a result, values for unsigned fields could be coerced incorrectly before DBus marshalling, causing type mismatch errors at runtime.

### What This PR Changes

1. Add unsigned unwrapping support in src/index.js.
2. Extend numeric validation to explicitly support unsigned values in src/index.js:

- Accept numeric values for type u.
- Enforce unsigned int bounds (0 to 4294967295).
- Return integer values for type u.

3. Include type u in validateNewValue numeric handling in src/index.js.
4. Add test coverage:

- Unwrap test for type u in src/tests/unwrapValueTest.js.
- setValuesLocally tests for valid and invalid unsigned values in src/tests/setValuesLocallyTest.js.

### Why This Is Safe

- Existing behavior for types i, d, s, b, ad, ai, as remains unchanged.
- Unsigned handling is now consistent across wrap, validate, and unwrap paths.
- Range checks prevent invalid negative or out-of-range unsigned values.

### Validation

- Reproduced runtime failure before fix when writing UtcTime as unsigned.
- Confirmed issue is resolved after this change in live testing.
- Added targeted tests to prevent regression.

### Notes
This addresses unsigned support end-to-end, rather than relying on downstream workarounds (such as changing declarations from u to i).